### PR TITLE
Added workaround for BR tag bug; see https://github.com/mermaid-js/mermaid/issues/1766.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function createFigures() {
       const {svg} = await mermaid.mermaidAPI.render(
         'diagram-' + figureNum, mermaidSource);
       const template = document.createElement('template');
-      const cleanedSvg = svg.trim().replace(/height="[0-9]*"/, '');
+      const cleanedSvg = svg.trim().replace(/height="[0-9]*"/, '').replaceAll('<br>', '</p><p>');
       template.innerHTML = cleanedSvg;
       figure.parentElement.prepend(template.content.firstChild);
       figure.remove();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/respec-mermaid#readme",
   "dependencies": {
-    "mermaid": "^10.6.1"
+    "mermaid": "^11.8.1"
   },
   "devDependencies": {
     "http-server": "^14.1.1",


### PR DESCRIPTION
Replacing HTML \<br\> with XHTML \<br/\> is essentially impossible; there are multiple points in Mermaid and ReSpec Mermaid that roll back the replacement. For example, line 43 of index.js:

```javascript
template.innerHTML = cleanedSvg;
```

This assignment hands control over to the DOM, which promptly reverts to \<br\>, even though the \<foreignObject\> content is XHTML.

To get around this, \<br\> tags are replaced with \</p\>\<p\> (closing and opening paragraph markers).

The end result is an XML-conformant SVG.